### PR TITLE
Add API key validation and connectivity check to poster workflow

### DIFF
--- a/.github/workflows/update-poster-paths.yml
+++ b/.github/workflows/update-poster-paths.yml
@@ -18,6 +18,23 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Validate TMDB API Key
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          if [ -z "$TMDB_API_KEY" ]; then
+            echo "Error: TMDB_API_KEY secret is not set or empty."
+            exit 1
+          fi
+          echo "TMDB_API_KEY secret is present."
+
+      - name: Test TMDb API Connectivity
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          curl --fail --silent --show-error "https://api.themoviedb.org/3/configuration?api_key=$TMDB_API_KEY" > /dev/null
+          echo "Successfully connected to TMDb API."
+
       - name: Install dependencies
         run: |
           npm install node-fetch@2

--- a/.github/workflows/update-poster-paths.yml
+++ b/.github/workflows/update-poster-paths.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
         run: |
-          curl --fail --silent --show-error "https://api.themoviedb.org/3/configuration?api_key=$TMDB_API_KEY" > /dev/null
+          curl --fail --silent --show-error -H "Authorization: Bearer $TMDB_API_KEY" "https://api.themoviedb.org/3/configuration" > /dev/null
           echo "Successfully connected to TMDb API."
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- validate `TMDB_API_KEY` secret before installing dependencies
- check TMDb API connectivity via curl in update-poster-paths workflow

## Testing
- `node .github/scripts/testTmdbApi.js`
- `node .github/scripts/updatePosterPaths.js`


------
https://chatgpt.com/codex/tasks/task_e_68beb4bb99dc832ca1698aec11923ad8