### PR TITLE
Add API key validation and connectivity check to poster workflow

### DIFF
--- a/.github/workflows/update-poster-paths.yml
+++ b/.github/workflows/update-poster-paths.yml
@@ -18,11 +18,28 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Validate TMDb API key
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          if [ -z "$TMDB_API_KEY" ]; then
+            echo "Error: TMDB_API_KEY secret is not set or empty."
+            exit 1
+          fi
+          echo "TMDB_API_KEY secret is present."
+
+      - name: Test TMDb API Connectivity
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          curl --fail --silent --show-error "https://api.themoviedb.org/3/configuration?api_key=$TMDB_API_KEY" > /dev/null
+          echo "Successfully connected to TMDb API."
+
       - name: Install dependencies
         run: |
-          npm install node-fetch@2
+          npm ci
 
-      - name: Test TMDB API Key
+      - name: Test TMDb API key
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
         run: |


### PR DESCRIPTION
## Summary
- validate `TMDB_API_KEY` secret before installing dependencies
- check TMDb API connectivity via curl
- install dependencies with `npm ci`
- use consistent TMDb naming

Closes #4

## Testing
- `TMDB_API_KEY=dummy node .github/scripts/testTmdbApi.js`
- `TMDB_API_KEY=dummy node .github/scripts/updatePosterPaths.js`


------
https://chatgpt.com/codex/tasks/task_e_68beb4bb99dc832ca1698aec11923ad8