### PR TITLE
Refine TMDb API key handling in poster workflow

### DIFF
--- a/.github/workflows/update-poster-paths.yml
+++ b/.github/workflows/update-poster-paths.yml
@@ -23,16 +23,16 @@ jobs:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
         run: |
           if [ -z "$TMDB_API_KEY" ]; then
-            echo "Error: TMDB_API_KEY secret is not set or empty."
+            echo "Error: TMDb API key secret is not set or empty."
             exit 1
           fi
-          echo "TMDB_API_KEY secret is present."
+          echo "TMDb API key secret is present."
 
       - name: Test TMDb API Connectivity
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
         run: |
-          curl --fail --silent --show-error "https://api.themoviedb.org/3/configuration?api_key=$TMDB_API_KEY" > /dev/null
+          curl --fail --silent --show-error -H "Authorization: Bearer $TMDB_API_KEY" "https://api.themoviedb.org/3/configuration" > /dev/null
           echo "Successfully connected to TMDb API."
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- use Authorization header for TMDb connectivity check
- clarify TMDb API key validation messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `TMDB_API_KEY=dummy node .github/scripts/testTmdbApi.js`
- `TMDB_API_KEY=dummy node .github/scripts/updatePosterPaths.js`


------
https://chatgpt.com/codex/tasks/task_e_68beb884ea00832cbdc94beefd3791eb