### PR TITLE
Fix broken TMDB thumbnails and add fallback placeholder

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -265,12 +265,23 @@ function getPosterUrl(title) {
   // Try normalized title first, then original title as fallback
   const posterPath = window.posterPaths[normalizedTitle] || window.posterPaths[title];
   
-  return posterPath ? `https://image.tmdb.org/t/p/w92${posterPath}` : "https://via.placeholder.com/56x84?text=No+Image";
+  // Use TMDB's image CDN; fall back to a placeholder if unavailable
+  return posterPath
+    ? `https://media.themoviedb.org/t/p/w92${posterPath}`
+    : "https://via.placeholder.com/56x84?text=No+Image";
 }
 
 function renderTable(rows) {
   const tbody = document.getElementById('table-body');
-  tbody.innerHTML = rows.map(r => `<tr><td>${r[0]}</td><td>${r[1]}</td><td>${r[2]}</td><td><img src="${getPosterUrl(r[2])}" alt="${r[2]}" loading="lazy" /></td><td>${r[3]}</td></tr>`).join('');
+  // Each poster falls back to a placeholder if the image fails to load
+  tbody.innerHTML = rows
+    .map(
+      r =>
+        `<tr><td>${r[0]}</td><td>${r[1]}</td><td>${r[2]}</td><td><img src="${getPosterUrl(
+          r[2]
+        )}" alt="${r[2]}" loading="lazy" onerror="this.src='https://via.placeholder.com/56x84?text=No+Image'" referrerpolicy="no-referrer" /></td><td>${r[3]}</td></tr>`
+    )
+    .join('');
 }
 
 function reorderTable() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -279,9 +279,19 @@ function renderTable(rows) {
       r =>
         `<tr><td>${r[0]}</td><td>${r[1]}</td><td>${r[2]}</td><td><img src="${getPosterUrl(
           r[2]
-        )}" alt="${r[2]}" loading="lazy" onerror="this.src='https://via.placeholder.com/56x84?text=No+Image'" referrerpolicy="no-referrer" /></td><td>${r[3]}</td></tr>`
+        )}" alt="${r[2]}" loading="lazy" referrerpolicy="no-referrer" /></td><td>${r[3]}</td></tr>`
     )
     .join('');
+
+  // Add error event listeners to all images for fallback
+  const fallbackUrl = "https://via.placeholder.com/56x84?text=No+Image";
+  tbody.querySelectorAll('img').forEach(img => {
+    img.addEventListener('error', function() {
+      if (this.src !== fallbackUrl) {
+        this.src = fallbackUrl;
+      }
+    });
+  });
 }
 
 function reorderTable() {


### PR DESCRIPTION
## Summary
- Switch poster images to the new TMDB CDN
- Add graceful fallback for posters that fail to load

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bef64b95f0832c83eb405b5d2b383e